### PR TITLE
Improve cluster management

### DIFF
--- a/sdc/__init__.py
+++ b/sdc/__init__.py
@@ -1,4 +1,3 @@
-import warnings
 import dask
 import xarray as xr
 from sdc.cluster import start_slurm_cluster
@@ -6,6 +5,4 @@ from sdc.cluster import start_slurm_cluster
 dask.config.set({'array.chunk-size': '256MiB'})
 xr.set_options(keep_attrs=True)
 
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore", category=UserWarning)
-    dask_client, cluster = start_slurm_cluster()
+dask_client, cluster = start_slurm_cluster()

--- a/sdc/cluster.py
+++ b/sdc/cluster.py
@@ -9,6 +9,7 @@ def start_slurm_cluster(cores: int = 10,
                         processes: int = 1,
                         memory: str = '20 GiB',
                         walltime: str = '00:30:00',
+                        log_directory: str = None,
                         scheduler_options: dict = None) -> (Client, SLURMCluster):
     """
     Start a dask_jobqueue.SLURMCluster and a distributed.Client. The cluster will
@@ -25,6 +26,9 @@ def start_slurm_cluster(cores: int = 10,
         Total amount of memory per job. Default is '20 GiB'.
     walltime : str, optional
         The walltime for the job in the format HH:MM:SS. Default is '00:30:00'.
+    log_directory : str, optional
+        The directory to write the log files to. Default is None, which writes the log
+        files to ~/.sdc_logs/<date>.
     scheduler_options : dict, optional
         Additional scheduler options. Default is None, which sets the dashboard address
         to a free port based on the user id.
@@ -48,8 +52,11 @@ def start_slurm_cluster(cores: int = 10,
     down as needed.
     """
     local_directory = os.path.join('/', 'scratch', os.getenv('USER'))
-    now = datetime.datetime.now().strftime('%Y-%m-%dT%H:%M')
-    log_directory = os.path.join(os.getenv('HOME'), '.sdc_logs', now)
+    
+    if log_directory is None:
+        if os.path.exists(os.getenv('HOME')):
+            now = datetime.datetime.now().strftime('%Y-%m-%dT%H:%M')
+            log_directory = os.path.join(os.getenv('HOME'), '.sdc_logs', now)
     
     if scheduler_options is None:
         port = _dashboard_port()

--- a/sdc/cluster.py
+++ b/sdc/cluster.py
@@ -3,9 +3,9 @@ from dask_jobqueue import SLURMCluster
 from distributed import Client
 
 
-def start_slurm_cluster(cores: int = 4,
+def start_slurm_cluster(cores: int = 10,
                         processes: int = 1,
-                        memory: str = "10GB",
+                        memory: str = "20 GiB",
                         walltime: str = "00:30:00") -> (Client, SLURMCluster):
     """
     Start a dask_jobqueue.SLURMCluster and a distributed.Client. The cluster will
@@ -14,12 +14,12 @@ def start_slurm_cluster(cores: int = 4,
     Parameters
     ----------
     cores : int, optional
-        Total number of cores per job. Default is 4.
+        Total number of cores per job. Default is 10.
     processes : int, optional
         Number of (Python) processes per job. Default is 1, which is a good default for
         numpy-based workloads.
     memory : str, optional
-        Total amount of memory per job. Default is "10GB".
+        Total amount of memory per job. Default is "20 GiB".
     walltime : str, optional
         The walltime for the job in the format HH:MM:SS. Default is "00:30:00".
     

--- a/sdc/cluster.py
+++ b/sdc/cluster.py
@@ -1,4 +1,5 @@
 import os
+import datetime
 from dask_jobqueue import SLURMCluster
 from distributed import Client
 
@@ -42,6 +43,8 @@ def start_slurm_cluster(cores: int = 10,
     down as needed.
     """
     local_directory = os.path.join('/', 'scratch', os.getenv('USER'))
+    now = datetime.datetime.now().strftime('%Y-%m-%dT%H:%M')
+    log_directory = os.path.join(os.getenv('HOME'), '.sdc_logs', now)
     
     cluster = SLURMCluster(queue='short',
                            cores=cores,
@@ -51,7 +54,8 @@ def start_slurm_cluster(cores: int = 10,
                            interface='ib0',
                            job_script_prologue=['mkdir -p /scratch/$USER'],
                            worker_extra_args=['--lifetime', '25m'],
-                           local_directory=local_directory)
+                           local_directory=local_directory,
+                           log_directory=log_directory)
     
     dask_client = Client(cluster)
     cluster.adapt(minimum_jobs=1, maximum_jobs=4,


### PR DESCRIPTION
This PR includes various improvements of the `sdc.cluster` module, which uses [`dask_jobqueue.SLURMCluster`](https://jobqueue.dask.org/en/latest/generated/dask_jobqueue.SLURMCluster.html#dask_jobqueue.SLURMCluster) to manage cluster resources. A summary of the changes:
- Change default values for `cores` and `memory` parameters
- Add `log_directory` parameter, which by default will write log files to subdirectories of `~/.sdc_logs`
- Add `scheduler_options` parameter, which by default sets the dask dashboard port to a free port that depends on the user id
- Set `interface='ib0'` (Infiniband) 
- Set `job_script_prologue=['mkdir -p /scratch/$USER']` and `local_directory='/scratch/$USER'` (as suggested [here](https://confluence.uni-jena.de/display/URZ010SD/Data+Management#DataManagement-ScratchScratch))
- Adjust `cluster.adapt()`-parameters