### PR TITLE
Change backend from `stackstac` to `odc-stac`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - pytz
   - shapely
   - pystac
-  - stackstac
+  - odc-stac
   - fiona
   - xclim
   - numpy==1.24.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "pytz",
     "shapely",
     "pystac",
-    "stackstac",
+    "odc-stac",
     "fiona",
     "xclim",
     "numpy==1.24.4"

--- a/sdc/s2.py
+++ b/sdc/s2.py
@@ -1,5 +1,5 @@
 from pystac import Catalog
-import numpy as np
+from odc.stac import load as odc_stac_load
 
 from typing import Optional, Tuple, Any
 from xarray import Dataset, DataArray
@@ -45,16 +45,13 @@ def load_s2_l2a(bounds: Tuple[float, float, float, float],
     https://docs.digitalearthafrica.org/en/latest/data_specs/Sentinel-2_Level-2A_specs.html
     """
     product = 's2_l2a'
-    measurements = ('B02', 'B03', 'B04',  # Blue, Green, Red (10 m)
-                    'B05', 'B06', 'B07',  # Red Edge 1, 2, 3 (20 m)
-                    'B08',                # NIR (10 m)
-                    'B8A',                # NIR 2 (20 m)
-                    'B09',                # Water Vapour (60 m)
-                    'B11', 'B12')         # SWIR 1, SWIR 2 (20 m)
-    fill_value = 0
-    dtype = np.dtype("uint16")
-    out_dtype = "float32"
-    params = utils.common_params()
+    bands = ['B02', 'B03', 'B04',  # Blue, Green, Red (10 m)
+             'B05', 'B06', 'B07',  # Red Edge 1, 2, 3 (20 m)
+             'B08',                # NIR (10 m)
+             'B8A',                # NIR 2 (20 m)
+             'B09',                # Water Vapour (60 m)
+             'B11', 'B12']         # SWIR 1, SWIR 2 (20 m)
+    common_params = utils.common_params()
     
     # Load and filter STAC Items
     catalog = Catalog.from_file(utils.get_catalog_path(product=product))
@@ -62,62 +59,38 @@ def load_s2_l2a(bounds: Tuple[float, float, float, float],
                                          time_range=time_range,
                                          time_pattern=time_pattern)
     
-    # https://github.com/gjoseph92/stackstac/issues/20
-    items = utils.convert_asset_hrefs(list_stac_obj=items, href_type='absolute')
-    
     # Turn into dask-based xarray.Dataset
-    stackstac_params = {'items': items, 'assets': list(measurements), 'bounds': bounds,
-                        'dtype': dtype, 'fill_value': fill_value}
-    stackstac_params.update(params)
-    da = utils.stackstac_wrapper(params=stackstac_params)
-    ds = utils.dataarray_to_dataset(da=da)
+    ds = odc_stac_load(items=items, bands=bands, bbox=list(bounds), dtype='uint16',
+                       **common_params)
     
-    # Apply cloud mask
     if apply_mask:
-        params['bounds'] = bounds
-        valid = _mask(items=items, params=params)
-        ds = ds.where(valid, other=0, drop=True)
+        valid = _mask(items=items, bounds=bounds)
+        ds = ds.where(valid, other=0)
     
-    # Normalize the values to range [0, 1] and convert to `out_dtype`
+    # Normalize the values to range [0, 1] and convert to float32
     ds = ds / 10000
-    ds = ds.where((ds > 0) & (ds <= 1)).astype(out_dtype)
+    ds = ds.where((ds > 0) & (ds <= 1)).astype("float32")
     
     return ds
 
 
 def _mask(items: list[Item],
-          params: dict[str, Any]) -> DataArray:
+          bounds: Tuple[float, float, float, float]) -> DataArray:
     """
     Creates a valid-data mask from the `SCL` (Scene Classification Layer) band of
     Sentinel-2 L2A data.
-    
-    Parameters
-    ----------
-    items : list[Item]
-        A list of STAC Items from Sentinel-2 L2A data.
-    params : dict[str, Any]
-        Parameters to pass to `stackstac.stack`
-    
-    Returns
-    -------
-    DataArray
-        An xarray DataArray containing the valid-data mask.
     
     Notes
     -----
     An overview table of the SCL classes can be found in Table 3:
     https://docs.digitalearthafrica.org/en/latest/data_specs/Sentinel-2_Level-2A_specs.html#Specifications
     """
-    stackstac_params = {'items': items, 'assets': ['SCL'], 'dtype': np.dtype("uint8"),
-                        'fill_value': 0}
-    stackstac_params.update(params)
-    da = utils.stackstac_wrapper(params=stackstac_params)
-    
-    scl = da.sel(band='SCL')
+    ds = odc_stac_load(items=items, bands='SCL', bbox=list(bounds), 
+                       crs='EPSG:4326', resolution=0.0002)
     mask = (
-            (scl == 4) |  # Vegetation
-            (scl == 5) |  # Bare soils
-            (scl == 6) |  # Water
-            (scl == 7)    # Unclassified
+            (ds.SCL == 4) |  # Vegetation
+            (ds.SCL == 5) |  # Bare soils
+            (ds.SCL == 6) |  # Water
+            (ds.SCL == 7)    # Unclassified
     )
-    return mask.compute()
+    return mask

--- a/sdc/utils.py
+++ b/sdc/utils.py
@@ -1,4 +1,3 @@
-import warnings
 from copy import deepcopy
 from pathlib import Path
 import numpy as np
@@ -41,12 +40,10 @@ def common_params() -> dict[str, Any]:
     dict[str, Any]
          Dictionary of parameters that are common to all products.
     """
-    from rasterio.enums import Resampling
-    return {"epsg": 4326,
-            "resolution": 0.0002,  # actually pixel spacing, not resolution!
-            "resampling": Resampling['bilinear'],
-            "xy_coords": 'center',
-            "chunksize": (-1, 1, 'auto', 'auto')}
+    return {"crs": 'EPSG:4326',
+            "resolution": 0.0002,
+            "resampling": 'bilinear',
+            "chunks": {'time': -1, 'latitude': 'auto', 'longitude': 'auto'}}
 
 
 def convert_asset_hrefs(list_stac_obj: List[Catalog | Collection | Item],
@@ -77,86 +74,6 @@ def convert_asset_hrefs(list_stac_obj: List[Catalog | Collection | Item],
         elif href_type == 'relative':
             stac_obj.make_asset_hrefs_relative()
     return list_stac_obj_copy
-
-
-def dataarray_to_dataset(da: DataArray) -> Dataset:
-    """
-    Converts a DataArray loaded using the stackstac library to a Dataset.
-    
-    Parameters
-    ----------
-    da : DataArray
-        The DataArray to convert.
-    
-    Returns
-    -------
-    Dataset
-        The converted Dataset with band dimension dropped and band coordinates saved as attrs in variables.
-    
-    Notes
-    -----
-    Source: https://github.com/gjoseph92/stackstac/discussions/198#discussion-4760525
-    """
-    stack = da.copy()
-    ds = stack.to_dataset("band")
-    for coord, da in ds.band.coords.items():
-        if "band" in da.dims:
-            for i, band in enumerate(stack.band.values):
-                ds[band].attrs[coord] = da.values[i]
-    
-    ds = ds.drop_dims("band")
-    return ds
-
-
-def stackstac_wrapper(params: dict[str, Any]) -> DataArray:
-    """
-    Wrapper function for stackstac to avoid a pandas UserWarning if the version of stackstac is <= 0.5.0.
-    
-    Parameters
-    ----------
-    params : dict[str, Any]
-        Parameters to pass to stackstac.stack.
-    
-    Returns
-    -------
-    DataArray
-        An xarray DataArray containing the stacked data.
-    """
-    import stackstac
-    if stackstac.__version__ < "0.6.0":
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=UserWarning)
-            da = stackstac.stack(**params)
-    else:
-        da = stackstac.stack(**params)
-    
-    return da
-
-
-def groupby_solarday(ds: Dataset) -> Dataset:
-    """
-    Groups the observations of all data variables in a Dataset by calculating the mean for each solar day.
-    
-    Parameters
-    ----------
-    ds : Dataset
-        The Dataset to group by solar day.
-    
-    Returns
-    -------
-    ds_copy : Dataset
-        The grouped Dataset.
-    
-    Notes
-    -----
-    - This will result in coordinates that include the time-dimension to be dropped. Filter-operations using these
-    coordinates should be done before calling this function.
-    - The time coordinate will be rounded down to the nearest day.
-    """
-    ds_copy = ds.copy(deep=True)
-    ds_copy.coords['time'] = ds_copy.time.dt.floor('1D')
-    ds_copy = ds_copy.groupby('time').mean()
-    return ds_copy
 
 
 def ds_nanquantiles(ds: Dataset,


### PR DESCRIPTION
Due to performance issues with `stackstac` + `dask_jobqueue.SLURMCluster`, the backend will be changed to `odc-stac` for now. Need to investigate further before adding `stackstac` back as an optional backend. 

The only major change for users is the lack of exposed STAC metadata in the loaded `xarray.Dataset`. 