### PR TITLE
Improve application of masks

### DIFF
--- a/sdc/load.py
+++ b/sdc/load.py
@@ -12,7 +12,7 @@ def load_product(product: str,
                  vec: str,
                  time_range: Optional[Tuple[str, str]] = None,
                  time_pattern: Optional[str] = '%Y-%m-%d',
-                 apply_mask: bool = True,
+                 apply_mask: bool = True                 
                  ) -> Dataset:
     """
     Load data products available in the SALDi Data Cube (SDC).

--- a/sdc/load.py
+++ b/sdc/load.py
@@ -12,7 +12,7 @@ def load_product(product: str,
                  vec: str,
                  time_range: Optional[Tuple[str, str]] = None,
                  time_pattern: Optional[str] = '%Y-%m-%d',
-                 apply_mask: bool = True                 
+                 apply_mask: bool = True
                  ) -> Dataset:
     """
     Load data products available in the SALDi Data Cube (SDC).

--- a/sdc/s1.py
+++ b/sdc/s1.py
@@ -48,7 +48,6 @@ def load_s1_rtc(bounds: Tuple[float, float, float, float],
     """
     product = 's1_rtc'
     bands = ['vv', 'vh', 'area']
-    common_params = utils.common_params()
     
     # Load and filter STAC Items
     catalog = Catalog.from_file(utils.get_catalog_path(product=product))
@@ -57,8 +56,8 @@ def load_s1_rtc(bounds: Tuple[float, float, float, float],
                                          time_pattern=time_pattern)
     
     # Turn into dask-based xarray.Dataset
-    ds = odc_stac_load(items=items, bands=bands, bbox=list(bounds), dtype='float32',
-                       **common_params)
+    ds = odc_stac_load(items=items, bands=bands, bbox=bounds, dtype='float32',
+                       **utils.common_params())
     
     if apply_mask:
         valid = _mask(items=items, bounds=bounds)

--- a/sdc/s1.py
+++ b/sdc/s1.py
@@ -73,8 +73,8 @@ def _mask(items: List[Item],
     An overview table of the data mask classes can be found in Table 3:
     https://docs.digitalearthafrica.org/en/latest/data_specs/Sentinel-1_specs.html
     """
-    ds = odc_stac_load(items=items, bands='mask', bbox=list(bounds),
-                       crs='EPSG:4326', resolution=0.0002)
+    ds = odc_stac_load(items=items, bands='mask', bbox=bounds, dtype='uint8',
+                       **utils.common_params())
     mask = (ds.mask == 1)
     return mask
 

--- a/sdc/s1.py
+++ b/sdc/s1.py
@@ -1,3 +1,5 @@
+import numpy as np
+import xarray as xr
 from pystac import Catalog
 from odc.stac import load as odc_stac_load
 
@@ -60,7 +62,7 @@ def load_s1_rtc(bounds: Tuple[float, float, float, float],
     
     if apply_mask:
         valid = _mask(items=items, bounds=bounds)
-        ds = ds.where(valid)
+        ds = xr.where(valid, ds, np.nan)
     
     return ds
 

--- a/sdc/s2.py
+++ b/sdc/s2.py
@@ -1,3 +1,4 @@
+import numpy as np
 import xarray as xr
 from pystac import Catalog
 from odc.stac import load as odc_stac_load
@@ -69,7 +70,8 @@ def load_s2_l2a(bounds: Tuple[float, float, float, float],
     
     # Normalize the values to range [0, 1] and convert to float32
     ds = ds / 10000
-    ds = ds.where((ds > 0) & (ds <= 1)).astype("float32")
+    cond = (ds > 0) & (ds <= 1)
+    ds = xr.where(cond, ds, np.nan).astype("float32")
     
     return ds
 

--- a/sdc/s2.py
+++ b/sdc/s2.py
@@ -14,7 +14,8 @@ import sdc.query as query
 def load_s2_l2a(bounds: Tuple[float, float, float, float],
                 time_range: Optional[Tuple[str, str]] = None,
                 time_pattern: str = '%Y-%m-%d',
-                apply_mask: bool = True) -> Dataset:
+                apply_mask: bool = True
+                ) -> Dataset:
     """
     Loads the Sentinel-2 L2A data product for an area of interest.
     
@@ -60,12 +61,16 @@ def load_s2_l2a(bounds: Tuple[float, float, float, float],
                                          time_range=time_range,
                                          time_pattern=time_pattern)
     
+    common_params = utils.common_params()
+    if not apply_mask:
+        common_params['chunks']['time'] = -1
+    
     # Turn into dask-based xarray.Dataset
     ds = odc_stac_load(items=items, bands=bands, bbox=bounds, dtype='uint16',
-                       **utils.common_params())
+                       **common_params)
     
     if apply_mask:
-        valid = _mask(items=items, bounds=bounds)
+        valid = _mask(items=items, bounds=bounds, common_params=common_params)
         ds = xr.where(valid, ds, 0)
     
     # Normalize the values to range [0, 1] and convert to float32
@@ -73,11 +78,17 @@ def load_s2_l2a(bounds: Tuple[float, float, float, float],
     cond = (ds > 0) & (ds <= 1)
     ds = xr.where(cond, ds, np.nan).astype("float32")
     
+    if apply_mask:
+        ds = ds.chunk({'time': -1,
+                       'latitude': common_params['chunks']['latitude'],
+                       'longitude': common_params['chunks']['longitude']})
     return ds
 
 
 def _mask(items: List[Item],
-          bounds: Tuple[float, float, float, float]) -> DataArray:
+          bounds: Tuple[float, float, float, float],
+          common_params: dict
+          ) -> DataArray:
     """
     Creates a valid-data mask from the `SCL` (Scene Classification Layer) band of
     Sentinel-2 L2A data.
@@ -88,7 +99,7 @@ def _mask(items: List[Item],
     https://docs.digitalearthafrica.org/en/latest/data_specs/Sentinel-2_Level-2A_specs.html#Specifications
     """
     ds = odc_stac_load(items=items, bands='SCL', bbox=bounds, dtype='uint8',
-                       **utils.common_params())
+                       **common_params)
     mask = (
             (ds.SCL == 4) |  # Vegetation
             (ds.SCL == 5) |  # Bare soils

--- a/sdc/s2.py
+++ b/sdc/s2.py
@@ -85,8 +85,8 @@ def _mask(items: List[Item],
     An overview table of the SCL classes can be found in Table 3:
     https://docs.digitalearthafrica.org/en/latest/data_specs/Sentinel-2_Level-2A_specs.html#Specifications
     """
-    ds = odc_stac_load(items=items, bands='SCL', bbox=list(bounds), 
-                       crs='EPSG:4326', resolution=0.0002)
+    ds = odc_stac_load(items=items, bands='SCL', bbox=bounds, dtype='uint8',
+                       **utils.common_params())
     mask = (
             (ds.SCL == 4) |  # Vegetation
             (ds.SCL == 5) |  # Bare soils

--- a/sdc/s2.py
+++ b/sdc/s2.py
@@ -52,7 +52,6 @@ def load_s2_l2a(bounds: Tuple[float, float, float, float],
              'B8A',                # NIR 2 (20 m)
              'B09',                # Water Vapour (60 m)
              'B11', 'B12']         # SWIR 1, SWIR 2 (20 m)
-    common_params = utils.common_params()
     
     # Load and filter STAC Items
     catalog = Catalog.from_file(utils.get_catalog_path(product=product))
@@ -61,8 +60,8 @@ def load_s2_l2a(bounds: Tuple[float, float, float, float],
                                          time_pattern=time_pattern)
     
     # Turn into dask-based xarray.Dataset
-    ds = odc_stac_load(items=items, bands=bands, bbox=list(bounds), dtype='uint16',
-                       **common_params)
+    ds = odc_stac_load(items=items, bands=bands, bbox=bounds, dtype='uint16',
+                       **utils.common_params())
     
     if apply_mask:
         valid = _mask(items=items, bounds=bounds)

--- a/sdc/s2.py
+++ b/sdc/s2.py
@@ -1,3 +1,4 @@
+import xarray as xr
 from pystac import Catalog
 from odc.stac import load as odc_stac_load
 
@@ -65,7 +66,7 @@ def load_s2_l2a(bounds: Tuple[float, float, float, float],
     
     if apply_mask:
         valid = _mask(items=items, bounds=bounds)
-        ds = ds.where(valid, other=0)
+        ds = xr.where(valid, ds, 0)
     
     # Normalize the values to range [0, 1] and convert to float32
     ds = ds / 10000

--- a/sdc/utils.py
+++ b/sdc/utils.py
@@ -45,7 +45,7 @@ def common_params() -> Dict[str, Any]:
     return {"crs": 'EPSG:4326',
             "resolution": 0.0002,
             "resampling": 'bilinear',
-            "chunks": {'time': -1, 'latitude': 'auto', 'longitude': 'auto'}}
+            "chunks": {'time': 1, 'latitude': 'auto', 'longitude': 'auto'}}
 
 
 def convert_asset_hrefs(list_stac_obj: List[Catalog | Collection | Item],


### PR DESCRIPTION
- Load masks with their native `dtype`
- Load masks lazily with the same `chunks`-parameter as the data product.
- Apply masks on acquisition-chunks first (`{'time': 1}`) then rechunk to time-chunks (`{'time': -1}`)
- Use `xarray.where` instead of `Dataset.where` as performance seems to be slightly better (https://github.com/pydata/xarray/issues/7516 might be relevant)