### PR TITLE
Tweak dask & cluster settings

### DIFF
--- a/sdc/__init__.py
+++ b/sdc/__init__.py
@@ -1,8 +1,6 @@
-import dask
 import xarray as xr
 from sdc.cluster import start_slurm_cluster
 
-dask.config.set({'array.chunk-size': '256MiB'})
 xr.set_options(keep_attrs=True)
 
 dask_client, cluster = start_slurm_cluster()

--- a/sdc/cluster.py
+++ b/sdc/cluster.py
@@ -72,7 +72,7 @@ def start_slurm_cluster(cores: int = 20,
                            interface='ib0',
                            job_script_prologue=['mkdir -p /scratch/$USER'],
                            worker_extra_args=['--lifetime', '25m',
-                                              '--lifetime-stagger', '4m'],
+                                              '--lifetime-stagger', '2m'],
                            local_directory=local_directory,
                            log_directory=log_directory,
                            scheduler_options=scheduler_options)

--- a/sdc/cluster.py
+++ b/sdc/cluster.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 
 def start_slurm_cluster(cores: int = 20,
-                        processes: int = 5,
+                        processes: int = 4,
                         memory: str = '40 GiB',
                         walltime: str = '00:45:00',
                         log_directory: Optional[str] = None,
@@ -23,7 +23,7 @@ def start_slurm_cluster(cores: int = 20,
     cores : int, optional
         Total number of cores per job. Default is 20.
     processes : int, optional
-        Number of processes per job. Default is 5.
+        Number of processes per job. Default is 4.
     memory : str, optional
         Total amount of memory per job. Default is '40 GiB'.
     walltime : str, optional

--- a/sdc/cluster.py
+++ b/sdc/cluster.py
@@ -7,9 +7,9 @@ from distributed import Client
 from typing import Optional
 
 
-def start_slurm_cluster(cores: int = 10,
-                        processes: int = 1,
-                        memory: str = '20 GiB',
+def start_slurm_cluster(cores: int = 20,
+                        processes: int = 5,
+                        memory: str = '40 GiB',
                         walltime: str = '00:30:00',
                         log_directory: Optional[str] = None,
                         scheduler_options: Optional[dict] = None
@@ -21,17 +21,16 @@ def start_slurm_cluster(cores: int = 10,
     Parameters
     ----------
     cores : int, optional
-        Total number of cores per job. Default is 10.
+        Total number of cores per job. Default is 20.
     processes : int, optional
-        Number of (Python) processes per job. Default is 1, which is a good default for
-        numpy-based workloads.
+        Number of processes per job. Default is 5.
     memory : str, optional
-        Total amount of memory per job. Default is '20 GiB'.
+        Total amount of memory per job. Default is '40 GiB'.
     walltime : str, optional
         The walltime for the job in the format HH:MM:SS. Default is '00:30:00'.
     log_directory : str, optional
         The directory to write the log files to. Default is None, which writes the log
-        files to ~/.sdc_logs/<date>.
+        files to ~/.sdc_logs/<YYYY-mm-ddTHH:MM>.
     scheduler_options : dict, optional
         Additional scheduler options. Default is None, which sets the dashboard address
         to a free port based on the user id.
@@ -72,13 +71,14 @@ def start_slurm_cluster(cores: int = 10,
                            walltime=walltime,
                            interface='ib0',
                            job_script_prologue=['mkdir -p /scratch/$USER'],
-                           worker_extra_args=['--lifetime', '25m'],
+                           worker_extra_args=['--lifetime', '25m',
+                                              '--lifetime-stagger', '4m'],
                            local_directory=local_directory,
                            log_directory=log_directory,
                            scheduler_options=scheduler_options)
     
     dask_client = Client(cluster)
-    cluster.adapt(minimum_jobs=1, maximum_jobs=4,
+    cluster.adapt(minimum_jobs=1, maximum_jobs=2,
                   # https://github.com/dask/dask-jobqueue/issues/498#issuecomment-1233716189
                   worker_key=lambda state: state.address.split(':')[0],
                   interval='10s')

--- a/sdc/cluster.py
+++ b/sdc/cluster.py
@@ -10,7 +10,7 @@ from typing import Optional
 def start_slurm_cluster(cores: int = 20,
                         processes: int = 5,
                         memory: str = '40 GiB',
-                        walltime: str = '00:30:00',
+                        walltime: str = '00:45:00',
                         log_directory: Optional[str] = None,
                         scheduler_options: Optional[dict] = None
                         ) -> (Client, SLURMCluster):
@@ -27,7 +27,7 @@ def start_slurm_cluster(cores: int = 20,
     memory : str, optional
         Total amount of memory per job. Default is '40 GiB'.
     walltime : str, optional
-        The walltime for the job in the format HH:MM:SS. Default is '00:30:00'.
+        The walltime for the job in the format HH:MM:SS. Default is '00:45:00'.
     log_directory : str, optional
         The directory to write the log files to. Default is None, which writes the log
         files to ~/.sdc_logs/<YYYY-mm-ddTHH:MM>.
@@ -71,7 +71,7 @@ def start_slurm_cluster(cores: int = 20,
                            walltime=walltime,
                            interface='ib0',
                            job_script_prologue=['mkdir -p /scratch/$USER'],
-                           worker_extra_args=['--lifetime', '25m',
+                           worker_extra_args=['--lifetime', '40m',
                                               '--lifetime-stagger', '2m'],
                            local_directory=local_directory,
                            log_directory=log_directory,

--- a/sdc/cluster.py
+++ b/sdc/cluster.py
@@ -10,7 +10,7 @@ from typing import Optional
 def start_slurm_cluster(cores: int = 20,
                         processes: int = 4,
                         memory: str = '40 GiB',
-                        walltime: str = '00:45:00',
+                        walltime: str = '00:30:00',
                         log_directory: Optional[str] = None,
                         scheduler_options: Optional[dict] = None
                         ) -> (Client, SLURMCluster):
@@ -27,7 +27,7 @@ def start_slurm_cluster(cores: int = 20,
     memory : str, optional
         Total amount of memory per job. Default is '40 GiB'.
     walltime : str, optional
-        The walltime for the job in the format HH:MM:SS. Default is '00:45:00'.
+        The walltime for the job in the format HH:MM:SS. Default is '00:30:00'.
     log_directory : str, optional
         The directory to write the log files to. Default is None, which writes the log
         files to ~/.sdc_logs/<YYYY-mm-ddTHH:MM>.
@@ -71,14 +71,14 @@ def start_slurm_cluster(cores: int = 20,
                            walltime=walltime,
                            interface='ib0',
                            job_script_prologue=['mkdir -p /scratch/$USER'],
-                           worker_extra_args=['--lifetime', '40m',
+                           worker_extra_args=['--lifetime', '25m',
                                               '--lifetime-stagger', '2m'],
                            local_directory=local_directory,
                            log_directory=log_directory,
                            scheduler_options=scheduler_options)
     
     dask_client = Client(cluster)
-    cluster.adapt(minimum_jobs=1, maximum_jobs=2,
+    cluster.adapt(minimum=1, maximum=8,
                   # https://github.com/dask/dask-jobqueue/issues/498#issuecomment-1233716189
                   worker_key=lambda state: state.address.split(':')[0],
                   interval='10s')


### PR DESCRIPTION
- Use the default 128MiB dask chunk size instead of 256MiB
- ~Increase default walltime due to issues with `cluster.adapt` and to lower the risk of not finishing long computations in time (see #8 )~
- Fix #8
- Adjust the default values of `start_slurm_cluster`:
    - `cores`: 10 -> 20
    - `processes`: 1 -> 4
    - `memory`: 20 GiB -> 40 GiB

The cluster will scale between 1 and 2 slurm jobs, each one spawning 4 dask workers. The 4 workers share the allocated resources of 20 threads and 40 GiB memory. The current maximum is therefore 40 threads and 80 GiB memory.