### PR TITLE
Remove mask for S1_RTC & Adjust S2_L2A mask

### DIFF
--- a/sdc/load.py
+++ b/sdc/load.py
@@ -12,7 +12,7 @@ def load_product(product: str,
                  vec: str,
                  time_range: Optional[Tuple[str, str]] = None,
                  time_pattern: Optional[str] = '%Y-%m-%d',
-                 apply_mask: bool = True
+                 s2_apply_mask: Optional[bool] = True
                  ) -> Dataset:
     """
     Load data products available in the SALDi Data Cube (SDC).
@@ -32,10 +32,10 @@ def load_product(product: str,
         None, which loads all available data.
     time_pattern : str, optional
         Time pattern to parse the time range. Default is '%Y-%m-%d'.
-    apply_mask : bool, optional
-        Whether to apply a quality mask to the data. Default is True. The specifics of
-        the mask depend on the product. See the documentation of the specific product
-        for details.
+    s2_apply_mask : bool, optional
+        Whether to apply a valid-data mask to the Sentinel-2 data. Default is True.
+        The mask is created from the `SCL` (Scene Classification Layer) band of the
+        product.
     
     Returns
     -------
@@ -54,13 +54,12 @@ def load_product(product: str,
     
     kwargs = {'bounds': bounds,
               'time_range': time_range,
-              'time_pattern': time_pattern,
-              'apply_mask': apply_mask}
+              'time_pattern': time_pattern}
     
     if product == 's1_rtc':
         ds = load_s1_rtc(**kwargs)
     elif product == 's2_l2a':
-        ds = load_s2_l2a(**kwargs)
+        ds = load_s2_l2a(apply_mask=s2_apply_mask, **kwargs)
     else:
         raise ValueError(f'Product {product} not supported')
     

--- a/sdc/s2.py
+++ b/sdc/s2.py
@@ -97,13 +97,15 @@ def _mask(items: List[Item],
     -----
     An overview table of the SCL classes can be found in Table 3:
     https://docs.digitalearthafrica.org/en/latest/data_specs/Sentinel-2_Level-2A_specs.html#Specifications
+    
+    The selection of which classes to consider as valid data is based on
+    Baetens et al. (2019): https://doi.org/10.3390/rs11040433
     """
     ds = odc_stac_load(items=items, bands='SCL', bbox=bounds, dtype='uint8',
                        **common_params)
-    mask = (
-            (ds.SCL == 4) |  # Vegetation
-            (ds.SCL == 5) |  # Bare soils
-            (ds.SCL == 6) |  # Water
-            (ds.SCL == 7)    # Unclassified
-    )
+    mask = ((ds.SCL == 2) |  # dark area pixels
+            (ds.SCL > 3) &   # vegetation, bare soils, water, unclassified
+            (ds.SCL <= 7) |
+            (ds.SCL == 11)   # snow/ice
+            )
     return mask

--- a/sdc/s2.py
+++ b/sdc/s2.py
@@ -99,7 +99,7 @@ def _mask(items: List[Item],
     https://docs.digitalearthafrica.org/en/latest/data_specs/Sentinel-2_Level-2A_specs.html#Specifications
     
     The selection of which classes to consider as valid data is based on
-    Baetens et al. (2019): https://doi.org/10.3390/rs11040433
+    Baetens et al. (2019): https://doi.org/10.3390/rs11040433 (Table 4).
     """
     ds = odc_stac_load(items=items, bands='SCL', bbox=bounds, dtype='uint8',
                        **common_params)

--- a/sdc/s2.py
+++ b/sdc/s2.py
@@ -62,8 +62,8 @@ def load_s2_l2a(bounds: Tuple[float, float, float, float],
                                          time_pattern=time_pattern)
     
     common_params = utils.common_params()
-    if not apply_mask:
-        common_params['chunks']['time'] = -1
+    if apply_mask:
+        common_params['chunks']['time'] = 1
     
     # Turn into dask-based xarray.Dataset
     ds = odc_stac_load(items=items, bands=bands, bbox=bounds, dtype='uint16',

--- a/sdc/utils.py
+++ b/sdc/utils.py
@@ -45,7 +45,7 @@ def common_params() -> Dict[str, Any]:
     return {"crs": 'EPSG:4326',
             "resolution": 0.0002,
             "resampling": 'bilinear',
-            "chunks": {'time': 1, 'latitude': 'auto', 'longitude': 'auto'}}
+            "chunks": {'time': -1, 'latitude': 'auto', 'longitude': 'auto'}}
 
 
 def convert_asset_hrefs(list_stac_obj: List[Catalog | Collection | Item],


### PR DESCRIPTION
- The S2_L2A mask has been slightly adjusted and is now based on Table 4 in [Baetens et al. (2019)](https://doi.org/10.3390/rs11040433)
- Due to the possibility of faulty mask layers in the S1_RTC product I have decided to completely remove it (for now). Here is an example of a valid pixel count for site 06, which shows that the application of the mask leads to a huge missing area...

Without mask:
![image](https://github.com/Jena-Earth-Observation-School/sdc-tools/assets/56583917/424f59c4-a705-4305-97b6-f5efd521fd95)

With mask:
![image](https://github.com/Jena-Earth-Observation-School/sdc-tools/assets/56583917/f33a2694-efb2-428b-a679-a80d531e4872)

In most cases there is not much of a benefit to apply the S1_RTC mask anyway and it just leads to a more complex computational graph. In terms of masking, S2_L2A for sure needs to be prioritized ([damn clouds!](https://media.giphy.com/media/fqtyYcXoDV0X6ss8Mf/giphy.gif)) instead of S1_RTC.
