### PR TITLE
Use `numbagg` to calculate nanquantiles

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -12,8 +12,7 @@ dependencies:
   - stackstac
   - odc-stac>=0.3.7
   - fiona
-  - xclim
-  - numpy==1.24.4
+  - numbagg>=0.6.1
   - flox
   - jupyter-book
 ############# Extras #############

--- a/environment.yml
+++ b/environment.yml
@@ -11,8 +11,7 @@ dependencies:
   - pystac
   - odc-stac>=0.3.7
   - fiona
-  - xclim
-  - numpy==1.24.4
+  - numbagg>=0.6.1
   - flox
 ############# Extras #############
   - spyndex

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,7 @@ dependencies = [
     "pystac",
     "odc-stac>=0.3.7",
     "fiona",
-    "xclim",
-    "numpy==1.24.4",
+    "numbagg>=0.6.1",
     "flox"
 ]
 


### PR DESCRIPTION
- Renames `sdc.utils.xclim_nanquantiles` to `sdc.utils.da_nanquantiles` and replaces the usage of `xclim.core.utils._nan_quantile` with `numbagg.nanquantiles` (Relevant: https://github.com/numbagg/numbagg/issues/161)
- Align `sdc.utils.da_nanquantiles` and `sdc.utils.ds_nanquantiles` with each other
- Some minor improvements (typing, docstings, etc)