### PR TITLE
Use `p2p` as default rechunk method

### DIFF
--- a/sdc/__init__.py
+++ b/sdc/__init__.py
@@ -1,6 +1,8 @@
+import dask
 import xarray as xr
 from sdc.cluster import start_slurm_cluster
 
+dask.config.set({"array.rechunk.method": "p2p"})
 xr.set_options(keep_attrs=True)
 
 dask_client, cluster = start_slurm_cluster()


### PR DESCRIPTION
Further information/background:
https://github.com/dask/distributed/issues/7507
https://discourse.pangeo.io/t/rechunking-large-data-at-constant-memory-in-dask-experimental/3266

Cluster memory usage can be lowered by quite a bit. The following example is the per-pixel median computation of S2 data with applied mask, which includes a rechunking step. `ds1` is without p2p, `ds2` is with p2p: 

<img width="562" alt="image" src="https://github.com/Jena-Earth-Observation-School/sdc-tools/assets/56583917/cb33bcb4-7fc9-4deb-9046-1a77b6e55198">

