### PR TITLE
Revert #29

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -7,7 +7,6 @@ dependencies:
   - dask-jobqueue
   - odc-stac>=0.3.7
   - numbagg>=0.6.1
-  - bottleneck
   - fiona
   - flox
   - pytz

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,6 @@ dependencies:
   - dask-jobqueue
   - odc-stac>=0.3.7
   - numbagg>=0.6.1
-  - bottleneck
   - fiona
   - flox
   - pytz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
     "dask-jobqueue",
     "odc-stac>=0.3.7",
     "numbagg>=0.6.1",
-    "bottleneck",
     "fiona",
     "flox",
     "pytz"


### PR DESCRIPTION
I was too quick with my decision. There seem to be some issues related to `bottleneck` (see https://github.com/pydata/xarray/issues/7344), it seems to slowly be replaced with `numbagg` (already included in environment with #20) and my own quick tests using the `use_bottleneck`-flag have not resulted in performance differences.