### PR TITLE
Feat: Improve data loading

### DIFF
--- a/sdc/load.py
+++ b/sdc/load.py
@@ -58,8 +58,8 @@ def load_product(product: str,
         parameters, see documentation of `odc.stac.load`:
         https://odc-stac.readthedocs.io/en/latest/_api/odc.stac.load.html#odc-stac-load
         If `None` (default), the default parameters will be used: 
-        - crs: 'EPSG:4326'
-        - resolution: 0.0002
+        - crs: 'EPSG:6933'
+        - resolution: 20
         - resampling: 'bilinear'
         - chunks: {'time': -1, 'latitude': 'auto', 'longitude': 'auto'}
     

--- a/sdc/load.py
+++ b/sdc/load.py
@@ -1,10 +1,11 @@
 from pathlib import Path
-import fiona
+import geopandas as gpd
 
 from typing import Optional
 from xarray import Dataset, DataArray
 
 from sdc.vec import get_site_bounds
+from sdc.products._ancillary import common_params
 import sdc.products as prod
 
 
@@ -68,6 +69,17 @@ def load_product(product: str,
     ds : Dataset or DataArray
         Xarray Dataset or DataArray containing the loaded data.
     """
+    crs = common_params().get('crs')
+    if override_defaults is not None:
+        print("[WARNING] Overriding default loading parameters is only recommended for "
+              "advanced users. Start with the default parameters and only override "
+              "them if you know what you are doing.")
+        if product == 'mswep':
+            print("[INFO] Overriding default loading parameters is currently not "
+                  "supported for the MSWEP product. Default parameters will be used "
+                  "instead.")
+        crs = override_defaults.get('crs')
+    
     if isinstance(vec, Path):
         vec = str(vec)
     if vec.lower() in ['site01', 'site02', 'site03', 'site04', 'site05', 'site06']:
@@ -77,18 +89,11 @@ def load_product(product: str,
                   "Only do so if you know what you are doing and have optimized your "
                   "workflow! It is recommended to start with a small subset to test "
                   "your workflow before scaling up.")
-        bounds = get_site_bounds(site=vec.lower())
+        bounds = get_site_bounds(site=vec.lower(), crs=crs)
     else:
-        bounds = fiona.open(vec, 'r').bounds
-    
-    if override_defaults is not None:
-        print("[WARNING] Overriding default loading parameters is only recommended for "
-              "advanced users. Start with the default parameters and only override "
-              "them if you know what you are doing.")
-        if product == 'mswep':
-            print("[INFO] Overriding default loading parameters is currently not "
-                  "supported for the MSWEP product. Default parameters will be used "
-                  "instead.")
+        vec_gdf = gpd.read_file(vec)
+        vec_gdf = vec_gdf.to_crs(crs)
+        bounds = tuple(vec_gdf.total_bounds)
     
     kwargs = {'bounds': bounds,
               'time_range': time_range,

--- a/sdc/products/_ancillary.py
+++ b/sdc/products/_ancillary.py
@@ -45,8 +45,8 @@ def common_params() -> dict[str, Any]:
     dict
          Dictionary of parameters that are common to all products.
     """
-    return {"crs": 'EPSG:4326',
-            "resolution": 0.0002,
+    return {"crs": 'EPSG:6933',
+            "resolution": 20,
             "resampling": 'bilinear',
             "chunks": {'time': -1, 'latitude': 'auto', 'longitude': 'auto'}}
 

--- a/sdc/products/_query.py
+++ b/sdc/products/_query.py
@@ -9,7 +9,7 @@ from pystac import Catalog, Collection, Item
 
 
 def filter_stac_catalog(catalog: Catalog,
-                        bbox: Optional[tuple[float, float, float, float]] = None,
+                        bbox: Optional[tuple[float]] = None,
                         collection_ids: Optional[list[str]] = None,
                         time_range: Optional[tuple[str, str]] = None,
                         time_pattern: Optional[str] = None

--- a/sdc/products/copdem.py
+++ b/sdc/products/copdem.py
@@ -11,7 +11,7 @@ from sdc.products import _ancillary as anc
 from sdc.products import _query as query
 
 
-def load_copdem(bounds: tuple[float, float, float, float],
+def load_copdem(bounds: tuple[float],
                 override_defaults: Optional[dict] = None
                 ) -> DataArray:
     """

--- a/sdc/products/copdem.py
+++ b/sdc/products/copdem.py
@@ -29,8 +29,8 @@ def load_copdem(bounds: tuple[float, float, float, float],
         parameters, see documentation of `odc.stac.load`:
         https://odc-stac.readthedocs.io/en/latest/_api/odc.stac.load.html#odc-stac-load
         If `None` (default), the default parameters will be used: 
-        - crs: 'EPSG:4326'
-        - resolution: 0.0002
+        - crs: 'EPSG:6933'
+        - resolution: 20
         - resampling: 'bilinear'
         - chunks: {'time': -1, 'latitude': 'auto', 'longitude': 'auto'}
     

--- a/sdc/products/remote.py
+++ b/sdc/products/remote.py
@@ -1,0 +1,79 @@
+from pystac_client import Client
+from odc.stac import configure_rio, stac_load
+
+from sdc import dask_client
+from sdc.products import _ancillary as anc
+
+from typing import Optional
+from xarray import Dataset
+
+
+def load_from_dea_stac(bounds: tuple[float, float, float, float],
+                       collection: str,
+                       time_range: tuple[str, str],
+                       stac_filter: Optional[str] = None,
+                       bands: Optional[list[str]] = None,
+                       override_defaults: Optional[dict] = None,
+                       verbose: Optional[bool] = False
+                       ) -> Dataset:
+    """
+    Load data from the DEA STAC Catalog.
+    
+    Parameters
+    ----------
+    bounds: tuple of float
+        The bounding box of the area of interest in the format (minx, miny, maxx, maxy).
+        Will be used to filter the STAC Catalog for intersecting STAC Collections.
+    collection : str
+        The name of the STAC Collection to load data from.
+    time_range : tuple of str
+        The time range in the format (start_time, end_time) to filter STAC Items by.
+    stac_filter : dict, optional
+        A dictionary of additional filters to apply to the STAC Items. See the STAC API
+        filter extension for more information.
+    bands : list of str, optional
+        A list of band names to load. Defaults to None, which will load all bands.
+    override_defaults : dict, optional
+        Dictionary of loading parameters to override the default parameters with.
+        Partial overriding is possible, i.e. only override a specific parameter while
+        keeping the others at their default values. For an overview of allowed
+        parameters, see documentation of `odc.stac.load`:
+        https://odc-stac.readthedocs.io/en/latest/_api/odc.stac.load.html#odc-stac-load
+        If `None` (default), the default parameters will be used:
+        - crs: 'EPSG:6933'
+        - resolution: 20
+        - resampling: 'bilinear'
+        - chunks: {'time': -1, 'latitude': 'auto', 'longitude': 'auto'}
+    verbose : bool, optional
+        Whether to print information about the loading process. Defaults to False.
+    
+    Returns
+    -------
+    Dataset
+        An xarray Dataset containing the loaded data.
+    """
+    configure_rio(
+        cloud_defaults=True,
+        aws={"aws_unsigned": True},
+        AWS_S3_ENDPOINT="s3.af-south-1.amazonaws.com",
+        client=dask_client
+    )
+    
+    catalog = Client.open("https://explorer.digitalearth.africa/stac")
+    query = catalog.search(
+        bbox=bounds,
+        collections=[collection],
+        filter=stac_filter,
+        datetime=f"{time_range[0]}/{time_range[1]}"
+    )
+    items = list(query.items())
+    
+    params = anc.common_params()
+    if override_defaults is not None:
+        params = anc.override_common_params(params=params, **override_defaults)
+    if verbose:
+        print(f"Loading {len(items)} STAC Items with the following parameters: "
+              f"{params}")
+        
+        ds = stac_load(items=items, bands=bands, bbox=bounds, **params)
+    return ds

--- a/sdc/products/remote.py
+++ b/sdc/products/remote.py
@@ -11,7 +11,7 @@ from xarray import Dataset
 def load_from_dea_stac(bounds: tuple[float, float, float, float],
                        collection: str,
                        time_range: tuple[str, str],
-                       stac_filter: Optional[str] = None,
+                       stac_filter: Optional[dict] = None,
                        bands: Optional[list[str]] = None,
                        override_defaults: Optional[dict] = None,
                        verbose: Optional[bool] = False
@@ -74,6 +74,6 @@ def load_from_dea_stac(bounds: tuple[float, float, float, float],
     if verbose:
         print(f"Loading {len(items)} STAC Items with the following parameters: "
               f"{params}")
-        
-        ds = stac_load(items=items, bands=bands, bbox=bounds, **params)
+    
+    ds = stac_load(items=items, bands=bands, bbox=bounds, **params)
     return ds

--- a/sdc/products/s1.py
+++ b/sdc/products/s1.py
@@ -39,11 +39,11 @@ def load_s1_rtc(bounds: tuple[float, float, float, float],
         parameters, see documentation of `odc.stac.load`:
         https://odc-stac.readthedocs.io/en/latest/_api/odc.stac.load.html#odc-stac-load
         If `None` (default), the default parameters will be used: 
-        - crs: 'EPSG:4326'
-        - resolution: 0.0002
+        - crs: 'EPSG:6933'
+        - resolution: 20
         - resampling: 'bilinear'
         - chunks: {'time': -1, 'latitude': 'auto', 'longitude': 'auto'}
-    bands: list of str, optional
+    bands : list of str, optional
         A list of band names to load. Defaults to None, which will load all bands.
     
     Returns
@@ -117,8 +117,8 @@ def load_s1_surfmi(bounds: tuple[float, float, float, float],
         parameters, see documentation of `odc.stac.load`:
         https://odc-stac.readthedocs.io/en/latest/_api/odc.stac.load.html#odc-stac-load
         If `None` (default), the default parameters will be used: 
-        - crs: 'EPSG:4326'
-        - resolution: 0.0002
+        - crs: 'EPSG:6933'
+        - resolution: 20
         - resampling: 'bilinear'
         - chunks: {'time': -1, 'latitude': 'auto', 'longitude': 'auto'}
     
@@ -198,8 +198,8 @@ def load_s1_coherence(bounds: tuple[float, float, float, float],
         parameters, see documentation of `odc.stac.load`:
         https://odc-stac.readthedocs.io/en/latest/_api/odc.stac.load.html#odc-stac-load
         If `None` (default), the default parameters will be used: 
-        - crs: 'EPSG:4326'
-        - resolution: 0.0002
+        - crs: 'EPSG:6933'
+        - resolution: 20
         - resampling: 'bilinear'
         - chunks: {'time': -1, 'latitude': 'auto', 'longitude': 'auto'}
     

--- a/sdc/products/s1.py
+++ b/sdc/products/s1.py
@@ -14,7 +14,8 @@ from sdc.products import _query as query
 def load_s1_rtc(bounds: tuple[float, float, float, float],
                 time_range: Optional[tuple[str, str]] = None,
                 time_pattern: Optional[str] = None,
-                override_defaults: Optional[dict] = None
+                override_defaults: Optional[dict] = None,
+                bands: Optional[list[str]] = None
                 ) -> Dataset:
     """
     Loads the Sentinel-1 RTC data product for an area of interest.
@@ -42,6 +43,8 @@ def load_s1_rtc(bounds: tuple[float, float, float, float],
         - resolution: 0.0002
         - resampling: 'bilinear'
         - chunks: {'time': -1, 'latitude': 'auto', 'longitude': 'auto'}
+    bands: list of str, optional
+        A list of band names to load. Defaults to None, which will load all bands.
     
     Returns
     -------
@@ -55,7 +58,8 @@ def load_s1_rtc(bounds: tuple[float, float, float, float],
     https://docs.digitalearthafrica.org/en/latest/data_specs/Sentinel-1_specs.html
     """
     product = 's1_rtc'
-    bands = ['vv', 'vh', 'area']
+    if bands is None:
+        bands = ['vv', 'vh', 'area', 'angle']
     
     # Load and filter STAC Items
     catalog = Catalog.from_file(anc.get_catalog_path(product=product))
@@ -70,7 +74,8 @@ def load_s1_rtc(bounds: tuple[float, float, float, float],
     # Turn into dask-based xarray.Dataset
     ds = odc_stac_load(items=items, bands=bands, bbox=bounds, dtype='float32',
                        **params)
-    ds['angle'] = _angle(items=items, bounds=bounds, params=params)
+    if 'angle' in bands:
+        ds['angle'] = _angle(items=items, bounds=bounds, params=params)
     return ds
 
 

--- a/sdc/products/s2.py
+++ b/sdc/products/s2.py
@@ -16,7 +16,8 @@ def load_s2_l2a(bounds: tuple[float, float, float, float] = None,
                 time_range: Optional[tuple[str, str]] = None,
                 time_pattern: Optional[str] = None,
                 apply_mask: bool = True,
-                override_defaults: Optional[dict] = None
+                override_defaults: Optional[dict] = None,
+                bands: Optional[list[str]] = None
                 ) -> Dataset:
     """
     Loads the Sentinel-2 L2A data product for an area of interest.
@@ -51,7 +52,8 @@ def load_s2_l2a(bounds: tuple[float, float, float, float] = None,
         - resolution: 0.0002
         - resampling: 'bilinear'
         - chunks: {'time': -1, 'latitude': 'auto', 'longitude': 'auto'}
-    
+    bands: list of str, optional
+        A list of band names to load. Defaults to None, which will load all bands.
     Returns
     -------
     Dataset
@@ -64,12 +66,13 @@ def load_s2_l2a(bounds: tuple[float, float, float, float] = None,
     https://docs.digitalearthafrica.org/en/latest/data_specs/Sentinel-2_Level-2A_specs.html
     """
     product = 's2_l2a'
-    bands = ['B02', 'B03', 'B04',  # Blue, Green, Red (10 m)
-             'B05', 'B06', 'B07',  # Red Edge 1, 2, 3 (20 m)
-             'B08',                # NIR (10 m)
-             'B8A',                # NIR 2 (20 m)
-             'B09',                # Water Vapour (60 m)
-             'B11', 'B12']         # SWIR 1, SWIR 2 (20 m)
+    if bands is None:
+        bands = ['B02', 'B03', 'B04',  # Blue, Green, Red (10 m)
+                 'B05', 'B06', 'B07',  # Red Edge 1, 2, 3 (20 m)
+                 'B08',                # NIR (10 m)
+                 'B8A',                # NIR 2 (20 m)
+                 'B09',                # Water Vapour (60 m)
+                 'B11', 'B12']         # SWIR 1, SWIR 2 (20 m)
     
     if bounds is None and collection_ids is None:
         raise ValueError("Either `bounds` or `collection_ids` must be provided.")

--- a/sdc/products/s2.py
+++ b/sdc/products/s2.py
@@ -52,11 +52,11 @@ def load_s2_l2a(bounds: tuple[float, float, float, float] = None,
         parameters, see documentation of `odc.stac.load`:
         https://odc-stac.readthedocs.io/en/latest/_api/odc.stac.load.html#odc-stac-load
         If `None` (default), the default parameters will be used: 
-        - crs: 'EPSG:4326'
-        - resolution: 0.0002
+        - crs: 'EPSG:6933'
+        - resolution: 20
         - resampling: 'bilinear'
         - chunks: {'time': -1, 'latitude': 'auto', 'longitude': 'auto'}
-    bands: list of str, optional
+    bands : list of str, optional
         A list of band names to load. Defaults to None, which will load all bands.
     Returns
     -------

--- a/sdc/products/sanlc.py
+++ b/sdc/products/sanlc.py
@@ -33,10 +33,12 @@ def load_sanlc(bounds: tuple[float, float, float, float],
         parameters, see documentation of `odc.stac.load`:
         https://odc-stac.readthedocs.io/en/latest/_api/odc.stac.load.html#odc-stac-load
         If `None` (default), the default parameters will be used: 
-        - crs: 'EPSG:4326'
-        - resolution: 0.0002
-        - resampling: 'bilinear'
+        - crs: 'EPSG:6933'
+        - resolution: 20
+        - resampling: 'nearest' (*)
         - chunks: {'time': -1, 'latitude': 'auto', 'longitude': 'auto'}
+        (*) This parameter is fixed for this specific product and cannot be
+        overridden.
     
     Returns
     -------

--- a/sdc/products/sanlc.py
+++ b/sdc/products/sanlc.py
@@ -8,7 +8,7 @@ from sdc.products import _ancillary as anc
 from sdc.products import _query as query
 
 
-def load_sanlc(bounds: tuple[float, float, float, float],
+def load_sanlc(bounds: tuple[float],
                year: Optional[int] = None,
                override_defaults: Optional[dict] = None
                ) -> DataArray:

--- a/sdc/vec.py
+++ b/sdc/vec.py
@@ -277,7 +277,8 @@ SITE06 = '''{
 }'''
 
 
-def get_site_bounds(site: str) -> tuple[float, float, float, float]:
+def get_site_bounds(site: str,
+                    crs: str) -> tuple[float]:
     """
     Get the bounds as a tuple of (min_x, min_y, max_x, max_y) of a SALDi site.
     
@@ -285,10 +286,12 @@ def get_site_bounds(site: str) -> tuple[float, float, float, float]:
     ----------
     site : str
         The SALDi site name in the format 'siteXX', where XX is the site number.
+    crs : str
+        The CRS of the bounds to return.
     
     Returns
     -------
-    bounds : tuple of float
+    tuple of float
         The bounds as a tuple of (min_x, min_y, max_x, max_y).    
     """
     driver = "GeoJSON"
@@ -307,9 +310,5 @@ def get_site_bounds(site: str) -> tuple[float, float, float, float]:
     else:
         raise ValueError(f'Site {site} not supported')
     
-    bounds = (gdf.bounds.minx.values[0],
-              gdf.bounds.miny.values[0],
-              gdf.bounds.maxx.values[0],
-              gdf.bounds.maxy.values[0])
-    
-    return bounds
+    gdf = gdf.to_crs(crs)
+    return tuple(gdf.total_bounds)


### PR DESCRIPTION
- New default loading CRS: [`'EPSG:6933'`](https://epsg.io/6933)
- New module: `products.remote` to load data from remote sources
  - New function:  `products.remote.load_from_dea_stac` for loading [Digital Earth Africa STAC Catalogs](https://explorer.digitalearth.africa/products)
- Improve calculation of vector bounds
- Add option to load specific bands in `products.s1.load_s1_rtc` and `products.s2.load_s2_l2a`
- Add option to group by acquisition slices in `products.s2.load_s2_l2a`