### PR TITLE
fix: revert change in default loading crs

### DIFF
--- a/sdc/load.py
+++ b/sdc/load.py
@@ -59,8 +59,8 @@ def load_product(product: str,
         parameters, see documentation of `odc.stac.load`:
         https://odc-stac.readthedocs.io/en/latest/_api/odc.stac.load.html#odc-stac-load
         If `None` (default), the default parameters will be used: 
-        - crs: 'EPSG:6933'
-        - resolution: 20
+        - crs: 'EPSG:4326'
+        - resolution: 0.0002
         - resampling: 'bilinear'
         - chunks: {'time': -1, 'latitude': 'auto', 'longitude': 'auto'}
     

--- a/sdc/products/_ancillary.py
+++ b/sdc/products/_ancillary.py
@@ -45,8 +45,8 @@ def common_params() -> dict[str, Any]:
     dict
          Dictionary of parameters that are common to all products.
     """
-    return {"crs": 'EPSG:6933',
-            "resolution": 20,
+    return {"crs": 'EPSG:4326',
+            "resolution": 0.0002,
             "resampling": 'bilinear',
             "chunks": {'time': -1, 'latitude': 'auto', 'longitude': 'auto'}}
 

--- a/sdc/products/copdem.py
+++ b/sdc/products/copdem.py
@@ -29,8 +29,8 @@ def load_copdem(bounds: tuple[float],
         parameters, see documentation of `odc.stac.load`:
         https://odc-stac.readthedocs.io/en/latest/_api/odc.stac.load.html#odc-stac-load
         If `None` (default), the default parameters will be used: 
-        - crs: 'EPSG:6933'
-        - resolution: 20
+        - crs: 'EPSG:4326'
+        - resolution: 0.0002
         - resampling: 'bilinear'
         - chunks: {'time': -1, 'latitude': 'auto', 'longitude': 'auto'}
     

--- a/sdc/products/remote.py
+++ b/sdc/products/remote.py
@@ -40,8 +40,8 @@ def load_from_dea_stac(bounds: tuple[float, float, float, float],
         parameters, see documentation of `odc.stac.load`:
         https://odc-stac.readthedocs.io/en/latest/_api/odc.stac.load.html#odc-stac-load
         If `None` (default), the default parameters will be used:
-        - crs: 'EPSG:6933'
-        - resolution: 20
+        - crs: 'EPSG:4326'
+        - resolution: 0.0002
         - resampling: 'bilinear'
         - chunks: {'time': -1, 'latitude': 'auto', 'longitude': 'auto'}
     verbose : bool, optional

--- a/sdc/products/s1.py
+++ b/sdc/products/s1.py
@@ -39,8 +39,8 @@ def load_s1_rtc(bounds: tuple[float, float, float, float],
         parameters, see documentation of `odc.stac.load`:
         https://odc-stac.readthedocs.io/en/latest/_api/odc.stac.load.html#odc-stac-load
         If `None` (default), the default parameters will be used: 
-        - crs: 'EPSG:6933'
-        - resolution: 20
+        - crs: 'EPSG:4326'
+        - resolution: 0.0002
         - resampling: 'bilinear'
         - chunks: {'time': -1, 'latitude': 'auto', 'longitude': 'auto'}
     bands : list of str, optional
@@ -117,8 +117,8 @@ def load_s1_surfmi(bounds: tuple[float, float, float, float],
         parameters, see documentation of `odc.stac.load`:
         https://odc-stac.readthedocs.io/en/latest/_api/odc.stac.load.html#odc-stac-load
         If `None` (default), the default parameters will be used: 
-        - crs: 'EPSG:6933'
-        - resolution: 20
+        - crs: 'EPSG:4326'
+        - resolution: 0.0002
         - resampling: 'bilinear'
         - chunks: {'time': -1, 'latitude': 'auto', 'longitude': 'auto'}
     
@@ -198,8 +198,8 @@ def load_s1_coherence(bounds: tuple[float, float, float, float],
         parameters, see documentation of `odc.stac.load`:
         https://odc-stac.readthedocs.io/en/latest/_api/odc.stac.load.html#odc-stac-load
         If `None` (default), the default parameters will be used: 
-        - crs: 'EPSG:6933'
-        - resolution: 20
+        - crs: 'EPSG:4326'
+        - resolution: 0.0002
         - resampling: 'bilinear'
         - chunks: {'time': -1, 'latitude': 'auto', 'longitude': 'auto'}
     

--- a/sdc/products/s2.py
+++ b/sdc/products/s2.py
@@ -52,8 +52,8 @@ def load_s2_l2a(bounds: tuple[float, float, float, float] = None,
         parameters, see documentation of `odc.stac.load`:
         https://odc-stac.readthedocs.io/en/latest/_api/odc.stac.load.html#odc-stac-load
         If `None` (default), the default parameters will be used: 
-        - crs: 'EPSG:6933'
-        - resolution: 20
+        - crs: 'EPSG:4326'
+        - resolution: 0.0002
         - resampling: 'bilinear'
         - chunks: {'time': -1, 'latitude': 'auto', 'longitude': 'auto'}
     bands : list of str, optional

--- a/sdc/products/sanlc.py
+++ b/sdc/products/sanlc.py
@@ -33,8 +33,8 @@ def load_sanlc(bounds: tuple[float],
         parameters, see documentation of `odc.stac.load`:
         https://odc-stac.readthedocs.io/en/latest/_api/odc.stac.load.html#odc-stac-load
         If `None` (default), the default parameters will be used: 
-        - crs: 'EPSG:6933'
-        - resolution: 20
+        - crs: 'EPSG:4326'
+        - resolution: 0.0002
         - resampling: 'nearest' (*)
         - chunks: {'time': -1, 'latitude': 'auto', 'longitude': 'auto'}
         (*) This parameter is fixed for this specific product and cannot be


### PR DESCRIPTION
This reverts the change in default CRS introduced in #55 