### PR TITLE
fix: Change default CRS for vector files

### DIFF
--- a/sdc/load.py
+++ b/sdc/load.py
@@ -4,10 +4,6 @@ import geopandas as gpd
 from typing import Optional
 from xarray import Dataset, DataArray
 
-from sdc.vec import get_site_bounds
-from sdc.products._ancillary import common_params
-import sdc.products as prod
-
 
 def load_product(product: str,
                  vec: str | Path,
@@ -69,6 +65,10 @@ def load_product(product: str,
     ds : Dataset or DataArray
         Xarray Dataset or DataArray containing the loaded data.
     """
+    from sdc.vec import get_site_bounds
+    from sdc.products._ancillary import common_params
+    import sdc.products as prod
+    
     crs = common_params().get('crs')
     if override_defaults is not None:
         print("[WARNING] Overriding default loading parameters is only recommended for "

--- a/sdc/load.py
+++ b/sdc/load.py
@@ -66,10 +66,8 @@ def load_product(product: str,
         Xarray Dataset or DataArray containing the loaded data.
     """
     from sdc.vec import get_site_bounds
-    from sdc.products._ancillary import common_params
     import sdc.products as prod
     
-    crs = common_params().get('crs')
     if override_defaults is not None:
         print("[WARNING] Overriding default loading parameters is only recommended for "
               "advanced users. Start with the default parameters and only override "
@@ -78,8 +76,9 @@ def load_product(product: str,
             print("[INFO] Overriding default loading parameters is currently not "
                   "supported for the MSWEP product. Default parameters will be used "
                   "instead.")
-        crs = override_defaults.get('crs')
     
+    # `bbox`-parameter of `odc.stac.load` needs to be in lat/lon!
+    crs = 4326
     if isinstance(vec, Path):
         vec = str(vec)
     if vec.lower() in ['site01', 'site02', 'site03', 'site04', 'site05', 'site06']:
@@ -100,18 +99,14 @@ def load_product(product: str,
               'time_pattern': time_pattern}
     
     if product == 's1_rtc':
-        ds = prod.load_s1_rtc(override_defaults=override_defaults, 
-                              **kwargs)
+        ds = prod.load_s1_rtc(override_defaults=override_defaults, **kwargs)
     elif product == 's1_surfmi':
-        ds = prod.load_s1_surfmi(override_defaults=override_defaults, 
-                                 **kwargs)
+        ds = prod.load_s1_surfmi(override_defaults=override_defaults, **kwargs)
     elif product == 's1_coh':
-        ds = prod.load_s1_coherence(override_defaults=override_defaults, 
-                                    **kwargs)
+        ds = prod.load_s1_coherence(override_defaults=override_defaults, **kwargs)
     elif product == 's2_l2a':
         ds = prod.load_s2_l2a(apply_mask=s2_apply_mask, 
-                              override_defaults=override_defaults, 
-                              **kwargs)
+                              override_defaults=override_defaults, **kwargs)
     elif product == 'sanlc':
         ds = prod.load_sanlc(bounds=bounds, 
                              year=sanlc_year, 

--- a/sdc/vec.py
+++ b/sdc/vec.py
@@ -278,7 +278,8 @@ SITE06 = '''{
 
 
 def get_site_bounds(site: str,
-                    crs: str) -> tuple[float]:
+                    crs: str | int = 4326
+                    ) -> tuple[float]:
     """
     Get the bounds as a tuple of (min_x, min_y, max_x, max_y) of a SALDi site.
     
@@ -294,19 +295,18 @@ def get_site_bounds(site: str,
     tuple of float
         The bounds as a tuple of (min_x, min_y, max_x, max_y).    
     """
-    driver = "GeoJSON"
     if site.lower() == 'site01':
-        gdf = gpd.read_file(SITE01, driver=driver)
+        gdf = gpd.read_file(SITE01)
     elif site.lower() == 'site02':
-        gdf = gpd.read_file(SITE02, driver=driver)
+        gdf = gpd.read_file(SITE02)
     elif site.lower() == 'site03':
-        gdf = gpd.read_file(SITE03, driver=driver)
+        gdf = gpd.read_file(SITE03)
     elif site.lower() == 'site04':
-        gdf = gpd.read_file(SITE04, driver=driver)
+        gdf = gpd.read_file(SITE04)
     elif site.lower() == 'site05':
-        gdf = gpd.read_file(SITE05, driver=driver)
+        gdf = gpd.read_file(SITE05)
     elif site.lower() == 'site06':
-        gdf = gpd.read_file(SITE06, driver=driver)
+        gdf = gpd.read_file(SITE06)
     else:
         raise ValueError(f'Site {site} not supported')
     


### PR DESCRIPTION
The `bbox`-parameter of `odc.stac.load` always needs coordinates in lat/lon so the input vector files for subsetting should be handled accordingly with default CRS 4326.