### PR TITLE
chore: update dependencies, pin `odc-stac` version

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -14,7 +14,7 @@ dependencies:
   - jupyter-book
   - matplotlib
   - numbagg>=0.8.0
-  - odc-stac>=0.3.9
+  - odc-stac<=0.3.9
   - rioxarray
   - rio-cogeo
   - rio-stac

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -2,15 +2,14 @@ name: dev_sdc_env
 channels:
   - conda-forge
 dependencies:
-  - python>=3.11
+  - python<3.13
+  - dask
   - dask-jobqueue>=0.8.5
   - dask-labextension
   - datashader
-  - fiona
   - flox
   - geopandas
   - hvplot
-  - ipycytoscape
   - jupyterlab>=4.1.0
   - jupyter-book
   - matplotlib

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - jupyterlab>=4.1.0
   - matplotlib
   - numbagg>=0.8.0
-  - odc-stac>=0.3.9
+  - odc-stac<=0.3.9
   - rioxarray
   - spyndex
   - xarray>=2024.2.0

--- a/environment.yml
+++ b/environment.yml
@@ -2,11 +2,11 @@ name: sdc_env
 channels:
   - conda-forge
 dependencies:
-  - python>=3.11
+  - python<3.13
+  - dask
   - dask-jobqueue>=0.8.5
   - dask-labextension
   - datashader
-  - fiona
   - flox
   - geopandas
   - hvplot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,16 @@ authors = [
 description = "Tools and tutorials for the SALDi Data Cube (SDC)"
 readme = "README.md"
 license = {text = "MIT License"}
-requires-python = ">=3.11"
+requires-python = "<3.13"
 dependencies = [
+    "dask",
     "dask-jobqueue>=0.8.5",
-    "fiona",
+    "datashader",
     "flox",
     "geopandas",
+    "hvplot",
     "jupyterlab>=4.1.0",
+    "matplotlib",
     "numbagg>=0.8.0",
     "odc-stac>=0.3.9",
     "rioxarray",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "jupyterlab>=4.1.0",
     "matplotlib",
     "numbagg>=0.8.0",
-    "odc-stac>=0.3.9",
+    "odc-stac<=0.3.9",
     "rioxarray",
     "spyndex",
     "xarray>=2024.2.0",


### PR DESCRIPTION
General update of dependencies and pinning `odc-stac` to version 0.3.9 or lower due to issues with auto chunking.