### PR TITLE
fix: cluster adapt / feat: switch slurm queue and adjust default values

### DIFF
--- a/sdc/cluster.py
+++ b/sdc/cluster.py
@@ -12,7 +12,7 @@ from typing import Optional
 def start_slurm_cluster(cores: int = 16,
                         processes: int = 2,
                         memory: str = '16 GiB',
-                        walltime: str = '00:30:00',
+                        walltime: str = '00:45:00',
                         log_directory: Optional[str] = None,
                         wait_timeout: int = 300
                         ) -> tuple[Client, SLURMCluster]:
@@ -29,7 +29,7 @@ def start_slurm_cluster(cores: int = 16,
     memory : str, optional
         Total amount of memory per job. Default is '16 GiB'.
     walltime : str, optional
-        The walltime for the job in the format HH:MM:SS. Default is '00:30:00'.
+        The walltime for the job in the format HH:MM:SS. Default is '00:45:00'.
     log_directory : str, optional
         The directory to write the log files to. Default is None, which writes the log
         files to ~/.sdc_logs/<YYYY-mm-ddTHH:MM>.
@@ -69,7 +69,7 @@ def start_slurm_cluster(cores: int = 16,
               'walltime': walltime,
               'interface': 'ib0',
               'job_script_prologue': ['mkdir -p /scratch/$USER'],
-              'worker_extra_args': ['--lifetime', '25m',
+              'worker_extra_args': ['--lifetime', '40m',
                                     '--lifetime-stagger', '4m'],
               'local_directory': os.path.join('/', 'scratch', user_name),
               'log_directory': log_directory,

--- a/sdc/cluster.py
+++ b/sdc/cluster.py
@@ -116,7 +116,7 @@ def _create_cluster(**kwargs) -> tuple[Client, SLURMCluster]:
     """Create a dask_jobqueue.SLURMCluster and a distributed.Client."""
     cluster = SLURMCluster(**kwargs)
     dask_client = Client(cluster)
-    cluster.adapt(minimum_jobs=1, maximum_jobs=3,
+    cluster.adapt(minimum=1, maximum=6,
                 # https://github.com/dask/dask-jobqueue/issues/498#issuecomment-1233716189
                 worker_key=lambda state: state.address.split(':')[0],
                 interval='10s')

--- a/sdc/cluster.py
+++ b/sdc/cluster.py
@@ -62,32 +62,37 @@ def start_slurm_cluster(cores: int = 16,
     port = _dashboard_port()
     scheduler_options = {'dashboard_address': f':{port}'}
     
-    cluster = SLURMCluster(queue='short',
-                           cores=cores,
-                           processes=processes,
-                           memory=memory,
-                           walltime=walltime,
-                           interface='ib0',
-                           job_script_prologue=['mkdir -p /scratch/$USER'],
-                           worker_extra_args=['--lifetime', '25m',
-                                              '--lifetime-stagger', '4m'],
-                           local_directory=os.path.join('/', 'scratch', user_name),
-                           log_directory=log_directory,
-                           scheduler_options=scheduler_options)
+    kwargs = {'queue': 'short',
+              'cores': cores,
+              'processes': processes,
+              'memory': memory,
+              'walltime': walltime,
+              'interface': 'ib0',
+              'job_script_prologue': ['mkdir -p /scratch/$USER'],
+              'worker_extra_args': ['--lifetime', '25m',
+                                    '--lifetime-stagger', '4m'],
+              'local_directory': os.path.join('/', 'scratch', user_name),
+              'log_directory': log_directory,
+              'scheduler_options': scheduler_options}
     
-    dask_client = Client(cluster)
-    cluster.adapt(minimum_jobs=1, maximum_jobs=3,
-                  # https://github.com/dask/dask-jobqueue/issues/498#issuecomment-1233716189
-                  worker_key=lambda state: state.address.split(':')[0],
-                  interval='10s')
+    dask_client, cluster = _create_cluster(**kwargs)
     
     start_time = time.time()
     time.sleep(10)
     print("[INFO] Trying to allocate requested resources on the cluster (timeout after 5 minutes)...")
+    queue_switched = False
     
     while not is_cluster_ready(dask_client):
         if time.time() - start_time > wait_timeout:
-            raise TimeoutError("[INFO] Cluster failed to start within timeout period of 5 minutes. This could be due to high demand on the cluster.")
+            if not queue_switched:
+                print("[INFO] The default 'short' queue is busy. Switching to 'standard' queue and retrying (timeout after 5 minutes)...")
+                cluster.close()
+                kwargs['queue'] = 'standard'
+                dask_client, cluster = _create_cluster(**kwargs)
+                start_time = time.time()
+                queue_switched = True
+            else:
+                raise TimeoutError("[INFO] Cluster failed to start within timeout period of 5 minutes. This could be due to high demand on the cluster.")
         time.sleep(10)
     
     print(f"[INFO] Cluster is ready for computation! :) Dask dashboard available via 'localhost:{port}'")
@@ -105,6 +110,17 @@ def _dashboard_port(port: int = 8787) -> int:
                    if x != '']:
         port += 1
     return port
+
+
+def _create_cluster(**kwargs) -> tuple[Client, SLURMCluster]:
+    """Create a dask_jobqueue.SLURMCluster and a distributed.Client."""
+    cluster = SLURMCluster(**kwargs)
+    dask_client = Client(cluster)
+    cluster.adapt(minimum_jobs=1, maximum_jobs=3,
+                # https://github.com/dask/dask-jobqueue/issues/498#issuecomment-1233716189
+                worker_key=lambda state: state.address.split(':')[0],
+                interval='10s')
+    return dask_client, cluster
 
 
 def is_cluster_ready(client: Client,

--- a/sdc/cluster.py
+++ b/sdc/cluster.py
@@ -79,23 +79,28 @@ def start_slurm_cluster(cores: int = 16,
     
     start_time = time.time()
     time.sleep(10)
-    print("[INFO] Trying to allocate requested resources on the cluster (timeout after 5 minutes)...")
+    print("[INFO] Trying to allocate requested resources on the cluster (timeout after "
+          "5 minutes)...")
     queue_switched = False
     
     while not is_cluster_ready(dask_client):
         if time.time() - start_time > wait_timeout:
             if not queue_switched:
-                print("[INFO] The default 'short' queue is busy. Switching to 'standard' queue and retrying (timeout after 5 minutes)...")
+                print("[INFO] The default 'short' queue is busy. Switching to "
+                      "'standard' queue and retrying (timeout after 5 minutes)...")
                 cluster.close()
                 kwargs['queue'] = 'standard'
                 dask_client, cluster = _create_cluster(**kwargs)
                 start_time = time.time()
                 queue_switched = True
             else:
-                raise TimeoutError("[INFO] Cluster failed to start within timeout period of 5 minutes. This could be due to high demand on the cluster.")
+                raise TimeoutError("[INFO] Cluster failed to start within timeout "
+                                   "period of 5 minutes. This could be due to high "
+                                   "demand on the cluster.")
         time.sleep(10)
     
-    print(f"[INFO] Cluster is ready for computation! :) Dask dashboard available via 'localhost:{port}'")
+    print(f"[INFO] Cluster is ready for computation! :) Dask dashboard available via "
+          f"'localhost:{port}'")
     return dask_client, cluster
 
 
@@ -162,7 +167,8 @@ def is_cluster_ready(client: Client,
                 recent_job_ids.append(job_id)
             else:
                 try:
-                    start_dt = datetime.datetime.strptime(start_time, '%Y-%m-%dT%H:%M:%S')
+                    start_dt = datetime.datetime.strptime(start_time,
+                                                          '%Y-%m-%dT%H:%M:%S')
                     if (current_time - start_dt).total_seconds() <= recent_job_time:
                         recent_job_ids.append(job_id)
                 except ValueError:


### PR DESCRIPTION
- If the `short` queue in Slurm is too busy, try to switch to `standard` queue. If also busy raise error
- Increase default walltime to 45 minutes
- Fix automatic scaling of cluster by using other `cluster.adapt` parameters (see also [here](https://github.com/dask/dask-jobqueue/issues/611#issuecomment-1805717922))